### PR TITLE
1.3.3 Update github profile link due to username change

### DIFF
--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -16,7 +16,7 @@ export function Footer() {
         >
           <ActionIcon
             component="a"
-            href="https://github.com/Nicolass2001"
+            href="https://github.com/npuy"
             size="lg"
             color="gray"
             variant="subtle"


### PR DESCRIPTION
This pull request includes a minor update to the `Footer` component. The GitHub profile link has been updated to point to a different user.

* Changed the `href` in the `ActionIcon` from `https://github.com/Nicolass2001` to `https://github.com/npuy` in `Footer.tsx`.